### PR TITLE
Add model option for QLoRA training

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,17 @@ ai-novel-writer/
 ## Quick Start
 1. Place your source PDFs in a folder, e.g. `pdfs/`.
 2. Install the Python requirements with `pip install -r requirements.txt`.
-3. Run `bash run_pipeline.sh pdfs/`.
+3. Run `bash run_pipeline.sh pdfs/ [model]`.
+   - The optional `model` argument can be a local path or HF repo. If omitted,
+     the value from `config.yaml` is used.
 4. After processing, the FastAPI server will run on `http://localhost:8000`.
+
+When invoking `qlora_train.py` directly, the same `--model` option is
+available:
+
+```bash
+python training/qlora_train.py data_ingest/dataset.jsonl --out training/novel_adapter --model /path/to/model
+```
 
 ### Endpoints
 - `POST /draft` `{outline: str}` → streamed chapter text.

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -4,13 +4,18 @@
 set -euo pipefail
 
 PDF_DIR=$1
+MODEL=${2-}
 if [ -z "$PDF_DIR" ]; then
-  echo "Usage: $0 <pdf_dir>"
+  echo "Usage: $0 <pdf_dir> [model]"
   exit 1
 fi
 
 python data_ingest/load_pdfs.py "$PDF_DIR" --out data_ingest/dataset.jsonl
-python training/qlora_train.py data_ingest/dataset.jsonl --out training/novel_adapter
+if [ -n "$MODEL" ]; then
+  python training/qlora_train.py data_ingest/dataset.jsonl --out training/novel_adapter --model "$MODEL"
+else
+  python training/qlora_train.py data_ingest/dataset.jsonl --out training/novel_adapter
+fi
 python training/merge_and_quantize.py training/novel_adapter --out models
 
 # Initialize story bible if not exists

--- a/training/qlora_train.py
+++ b/training/qlora_train.py
@@ -5,15 +5,17 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import LoraConfig, get_peft_model
 from datasets import load_dataset
+import yaml
 
 
 DEFAULT_MODEL = "meta-llama/Meta-Llama-3-8B-Instruct"
+CONFIG_PATH = Path("config.yaml")
 
 
-def train(data_path: Path, output_dir: Path, epochs: int = 3):
-    tokenizer = AutoTokenizer.from_pretrained(DEFAULT_MODEL)
+def train(data_path: Path, output_dir: Path, model_name: str = DEFAULT_MODEL, epochs: int = 3):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(
-        DEFAULT_MODEL,
+        model_name,
         torch_dtype=torch.float16,
         device_map="auto",
         load_in_4bit=True,
@@ -54,8 +56,17 @@ def main():
     parser = argparse.ArgumentParser(description="QLoRA fine-tuning")
     parser.add_argument("data", type=Path, help="Path to dataset.jsonl")
     parser.add_argument("--out", type=Path, default=Path("training/novel_adapter"))
+    parser.add_argument("--model", type=str, default=None, help="Base model path or HF repo")
     args = parser.parse_args()
-    train(args.data, args.out)
+    model_name = args.model
+    if model_name is None:
+        if CONFIG_PATH.exists():
+            with open(CONFIG_PATH, "r") as f:
+                cfg = yaml.safe_load(f) or {}
+            model_name = cfg.get("model", DEFAULT_MODEL)
+        else:
+            model_name = DEFAULT_MODEL
+    train(args.data, args.out, model_name=model_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying base model via `--model` in `training/qlora_train.py`
- propagate optional model argument in `run_pipeline.sh`
- document the new option and usage examples in `README.md`

## Testing
- `pip install scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444b1846688321871587bef30a6ec6