### PR TITLE
Update Quick Start with HF login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ ai-novel-writer/
 ## Quick Start
 1. Place your source PDFs in a folder, e.g. `pdfs/`.
 2. Install the Python requirements with `pip install -r requirements.txt`.
-3. Run `bash run_pipeline.sh pdfs/`.
-4. After processing, the FastAPI server will run on `http://localhost:8000`.
+3. Authenticate with `huggingface-cli login` and accept the Llama\-3 model license.
+4. Run `bash run_pipeline.sh pdfs/` (downloads the Llama\-3 base model using your HuggingFace token).
+5. After processing, the FastAPI server will run on `http://localhost:8000`.
 
 ### Endpoints
 - `POST /draft` `{outline: str}` → streamed chapter text.


### PR DESCRIPTION
## Summary
- expand the Quick Start instructions
- mention logging in with `huggingface-cli` and that the pipeline downloads Llama-3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444b1438608321b701f95952e8abb9